### PR TITLE
Fix for exporting images with correct resolution in landscape mode

### DIFF
--- a/android/src/main/java/com/ric/adv_camera/AdvCamera.java
+++ b/android/src/main/java/com/ric/adv_camera/AdvCamera.java
@@ -594,6 +594,11 @@ public class AdvCamera implements MethodChannel.MethodCallHandler,
 
             int reqHeight = metrics.heightPixels;
             int reqWidth = metrics.widthPixels;
+            // Fix for exporting image with correct resolution in landscape mode
+            if(reqWidth > reqHeight){
+            reqHeight = metrics.widthPixels;
+            reqWidth = metrics.heightPixels;
+            }
 
             options.inSampleSize = calculateInSampleSize(options, reqWidth, reqHeight);
 


### PR DESCRIPTION
Current implementation for android does not take into account the change in orientation when picture is taken in landscape mode.  Resulting in wrong resolution for output images. This fix ensures that output resolution is same for portrait and landscape mode.