### PR TITLE
Fix for permissions management

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1+2"
   async:
     dependency: transitive
     description:

--- a/lib/adv_camera.dart
+++ b/lib/adv_camera.dart
@@ -73,7 +73,7 @@ class _AdvCameraState extends State<AdvCamera> {
   CameraPreviewRatio _cameraPreviewRatio;
   CameraSessionPreset _cameraSessionPreset;
   FlashType _flashType;
-  bool hasPermission = false;
+  bool _hasPermission = false;
 
   @override
   void initState() {
@@ -83,12 +83,7 @@ class _AdvCameraState extends State<AdvCamera> {
     _flashType = widget.flashType;
 
     if (widget.checkPermissionAtStartup) {
-      AdvCameraPlugin.checkForPermission().then((value) {
-        if (this.mounted)
-          setState(() {
-            hasPermission = value;
-          });
-      });
+      AdvCameraPlugin.checkForPermission().then((value) => updatePermissionsState(value));
     }
   }
 
@@ -98,7 +93,7 @@ class _AdvCameraState extends State<AdvCamera> {
     String sessionPreset;
     String flashType;
 
-    if (!hasPermission) return Center(child: CircularProgressIndicator());
+    if (!_hasPermission) return Center(child: CircularProgressIndicator());
 
     switch (_flashType) {
       case FlashType.on:
@@ -274,6 +269,14 @@ class _AdvCameraState extends State<AdvCamera> {
   void onImageCaptured(String path) {
     if (widget.onImageCaptured != null) {
       widget.onImageCaptured(path);
+    }
+  }
+
+  void updatePermissionsState(bool value) {
+    if (this.mounted) {
+      setState(() {
+        _hasPermission = value;
+      });
     }
   }
 }

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -220,6 +220,10 @@ class AdvCameraController {
     return finalTypes;
   }
 
+  void grantPermissions() {
+    _advCameraState.updatePermissionsState(true);
+  }
+
 //  Future<void> changeCamera() async {
 //    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
 //    // https://github.com/flutter/flutter/issues/26431

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adv_camera
 description: An advanced camera with focus (with focus rectangle) and zoom feature.
-version: 1.3.1+1
+version: 1.3.1+2
 homepage: https://github.com/ricnaaru/adv_camera
 
 environment:


### PR DESCRIPTION
Pass `checkPermissionAtStartup: true` to bypass permission check by plugin and then call `_controller.grantPermissions()` to update the camera widget after the manual permission check is successful. 