### PR TITLE
Fix camera load when checkPermissionAtStartup is false

### DIFF
--- a/lib/adv_camera.dart
+++ b/lib/adv_camera.dart
@@ -98,7 +98,7 @@ class _AdvCameraState extends State<AdvCamera> {
     String sessionPreset;
     String flashType;
 
-    if (!hasPermission) return Center(child: CircularProgressIndicator());
+    if (widget.checkPermissionAtStartup && !hasPermission) return Center(child: CircularProgressIndicator());
 
     switch (_flashType) {
       case FlashType.on:


### PR DESCRIPTION
Alternatively `bool hasPermission = false;` could be set to `true` by default.